### PR TITLE
Sign .changes & .deb files using dpkg-sig

### DIFF
--- a/docker_base/scripts/build/sign-deb.sh
+++ b/docker_base/scripts/build/sign-deb.sh
@@ -33,7 +33,7 @@ main() {
   debug_echo "Key ID: ${SIGNING_KEY_FINGERPRINT}"
 
   debsign -p${NO_TTY_GPG_COMMAND} -k${SIGNING_KEY_FINGERPRINT} /build/*.changes
-  debsigs --sign=origin --default-key=${SIGNING_KEY_FINGERPRINT} -v /build/*.deb
+  debsigs --sign=origin -k ${SIGNING_KEY_FINGERPRINT} -v /build/*.deb
 }
 
 main

--- a/docker_base/scripts/build/sign-deb.sh
+++ b/docker_base/scripts/build/sign-deb.sh
@@ -33,7 +33,7 @@ main() {
   debug_echo "Key ID: ${SIGNING_KEY_FINGERPRINT}"
 
   debsign -p${NO_TTY_GPG_COMMAND} -k${SIGNING_KEY_FINGERPRINT} /build/*.changes
-  debsigs --sign=origin -k${SIGNING_KEY_FINGERPRINT} -v /build/*.deb
+  debsigs --sign=origin --default-key=${SIGNING_KEY_FINGERPRINT} -v /build/*.deb
 }
 
 main

--- a/docker_base/scripts/build/sign-deb.sh
+++ b/docker_base/scripts/build/sign-deb.sh
@@ -25,15 +25,17 @@ main() {
   SIGNING_KEY_FINGERPRINT=$(${NO_TTY_GPG_COMMAND} --with-colons --show-keys "${signing_key_path}" | grep "^fpr" | cut -d':' -f10 | head -n1)
 
   rm "${signing_key_path}"
-
   if [[ -z "${SIGNING_KEY_FINGERPRINT}" ]]; then
     return
   fi
 
   debug_echo "Key ID: ${SIGNING_KEY_FINGERPRINT}"
 
-  debsign -p${NO_TTY_GPG_COMMAND} -k${SIGNING_KEY_FINGERPRINT} /build/*.changes
-  debsigs --sign=origin -k ${SIGNING_KEY_FINGERPRINT} -v /build/*.deb
+  debug_echo "Signing .changes file"
+  dpkg-sig --sign builder --sign-changes full -k ${SIGNING_KEY_FINGERPRINT} /build/*.changes
+
+  debug_echo "Signing .deb files"
+  dpkg-sig --sign builder -k ${SIGNING_KEY_FINGERPRINT} -v /build/*.deb
 }
 
 main

--- a/docker_base/scripts/build/sign-deb.sh
+++ b/docker_base/scripts/build/sign-deb.sh
@@ -30,12 +30,13 @@ main() {
   fi
 
   debug_echo "Key ID: ${SIGNING_KEY_FINGERPRINT}"
+  GPG_OPTIONS="--no-tty -v --pinentry-mode loopback --batch --passphrase='$SIGNING_PASSPHRASE'"
 
   debug_echo "Signing .changes file"
-  dpkg-sig --sign builder --sign-changes full -k ${SIGNING_KEY_FINGERPRINT} /build/*.changes
+  dpkg-sig --sign builder --sign-changes full -k ${SIGNING_KEY_FINGERPRINT} --gpg-options ${GPG_OPTIONS} /build/*.changes
 
   debug_echo "Signing .deb files"
-  dpkg-sig --sign builder -k ${SIGNING_KEY_FINGERPRINT} -v /build/*.deb
+  dpkg-sig --sign builder -k "${SIGNING_KEY_FINGERPRINT}" -v --gpg-options ${GPG_OPTIONS} /build/*.deb
 }
 
 main

--- a/docker_base/scripts/build/sign-deb.sh
+++ b/docker_base/scripts/build/sign-deb.sh
@@ -33,6 +33,7 @@ main() {
   debug_echo "Key ID: ${SIGNING_KEY_FINGERPRINT}"
 
   debsign -p${NO_TTY_GPG_COMMAND} -k${SIGNING_KEY_FINGERPRINT} /build/*.changes
+  debsigs --sign=origin -k${SIGNING_KEY_FINGERPRINT} -v /build/*.deb
 }
 
 main

--- a/docker_base/scripts/setup/install-dev-packages.sh
+++ b/docker_base/scripts/setup/install-dev-packages.sh
@@ -15,7 +15,7 @@ debug_echo() {
   fi
 }
 
-dev_packages=("debhelper" "debsigs" "devscripts" "dpkg-dev" "fakeroot" "lintian" "sudo")
+dev_packages=("debhelper" "devscripts" "dpkg-dev" "dpkg-sig" "fakeroot" "lintian" "sudo")
 
 apt_get_install_opts="-y install --no-install-recommends"
 

--- a/docker_base/scripts/setup/install-dev-packages.sh
+++ b/docker_base/scripts/setup/install-dev-packages.sh
@@ -15,7 +15,7 @@ debug_echo() {
   fi
 }
 
-dev_packages=("debhelper" "devscripts" "dpkg-dev" "fakeroot" "lintian" "sudo")
+dev_packages=("debhelper" "debsigs" "devscripts" "dpkg-dev" "fakeroot" "lintian" "sudo")
 
 apt_get_install_opts="-y install --no-install-recommends"
 

--- a/main.js
+++ b/main.js
@@ -218,6 +218,7 @@ async function main() {
                 "--no-install-recommends",
                 ...backportsOpts,
                 "debhelper",
+                "debsigs",
                 "devscripts",
                 "dpkg-dev",
                 "fakeroot",

--- a/main.js
+++ b/main.js
@@ -218,9 +218,9 @@ async function main() {
                 "--no-install-recommends",
                 ...backportsOpts,
                 "debhelper",
-                "debsigs",
                 "devscripts",
                 "dpkg-dev",
+                "dpkg-sig",
                 "fakeroot",
                 "lintian",
                 "sudo"


### PR DESCRIPTION
Related ticket: https://pi-top.atlassian.net/browse/OS-1183

This PR includes changes to sign `.deb` files. The tool used to do so is `dpkg-sig`, which is more powerful than the alternative `debsigs` since it allows to sign `.changes` & `.dsc` files and supports signature verification in files (which is not natively supported by the other alternative). 

Also, changes were made in order to have `dpkg-sig` also sign `.changes` files so that all of our files are signed by the same tool.

Note that signatures created by `dpkg-sig` are not compatible with `debsigs` and vice versa.

Related read: this is a very Interesting blog [post](https://blog.packagecloud.io/eng/2014/10/28/howto-gpg-sign-verify-deb-packages-apt-repositories/)

To verify the signature of a file, you can run `dpkg-sig --verify <file>`. e.g.:
```
$ dpkg-sig -c *.changes
--- Processing changes file pi-top-4-miniscreen_5.0.1-2~8.gbp2bf15f_amd64.changes:
Processing ./pt-miniscreen_5.0.1-2~8.gbp2bf15f_all.deb...
UNKNOWNSIG _gpgbuilder E307B9B8
UNKNOWNSIG _gpgbuilder0 E307B9B8
```