### PR TITLE
Revert "Sign .changes & .deb files using dpkg-sig (#22)"

### DIFF
--- a/docker_base/scripts/build/sign-deb.sh
+++ b/docker_base/scripts/build/sign-deb.sh
@@ -25,18 +25,14 @@ main() {
   SIGNING_KEY_FINGERPRINT=$(${NO_TTY_GPG_COMMAND} --with-colons --show-keys "${signing_key_path}" | grep "^fpr" | cut -d':' -f10 | head -n1)
 
   rm "${signing_key_path}"
+
   if [[ -z "${SIGNING_KEY_FINGERPRINT}" ]]; then
     return
   fi
 
   debug_echo "Key ID: ${SIGNING_KEY_FINGERPRINT}"
-  GPG_OPTIONS="--no-tty -v --pinentry-mode loopback --batch --passphrase='$SIGNING_PASSPHRASE'"
 
-  debug_echo "Signing .changes file"
-  dpkg-sig --sign builder --sign-changes full -k ${SIGNING_KEY_FINGERPRINT} --gpg-options ${GPG_OPTIONS} /build/*.changes
-
-  debug_echo "Signing .deb files"
-  dpkg-sig --sign builder -k "${SIGNING_KEY_FINGERPRINT}" -v --gpg-options ${GPG_OPTIONS} /build/*.deb
+  debsign -p${NO_TTY_GPG_COMMAND} -k${SIGNING_KEY_FINGERPRINT} /build/*.changes
 }
 
 main

--- a/docker_base/scripts/setup/install-dev-packages.sh
+++ b/docker_base/scripts/setup/install-dev-packages.sh
@@ -15,7 +15,7 @@ debug_echo() {
   fi
 }
 
-dev_packages=("debhelper" "devscripts" "dpkg-dev" "dpkg-sig" "fakeroot" "lintian" "sudo")
+dev_packages=("debhelper" "devscripts" "dpkg-dev" "fakeroot" "lintian" "sudo")
 
 apt_get_install_opts="-y install --no-install-recommends"
 

--- a/main.js
+++ b/main.js
@@ -220,7 +220,6 @@ async function main() {
                 "debhelper",
                 "devscripts",
                 "dpkg-dev",
-                "dpkg-sig",
                 "fakeroot",
                 "lintian",
                 "sudo"


### PR DESCRIPTION
Ticket: [OS-1183](https://pi-top.atlassian.net/browse/OS-1183)

`dpkg-sig` will sign `deb` files but won't update their after-signature sizes in the `.changes` file, causing issues when validating our package using `dscverify`.

Reverting to what we had before to sign only the `.changes` & `.dsc` file should be enough for our packages to pass verifications made with `dscverify`:

```
$ dscverify ./pi-top-os-apt_2022.1.7_amd64.changes  --keyring /usr/share/keyrings/pi-top-os-backup.gpg
./pi-top-os-apt_2022.1.7_amd64.changes:
      Good signature found
   validating pi-top-os-apt_2022.1.7.dsc
      Good signature found
   validating pi-top-os-apt_2022.1.7.tar.xz
   validating pi-top-os-apt-source_2022.1.7_all.deb
   validating pi-top-os-apt_2022.1.7_amd64.buildinfo
      Good signature found
   validating pi-top-os-archive-keyring_2022.1.7_all.deb
   validating pi-top-os-experimental-apt-source_2022.1.7_all.deb
   validating pi-top-os-testing-apt-source_2022.1.7_all.deb
   validating pi-top-os-unstable-apt-source_2022.1.7_all.deb
All files validated successfully.
```