### PR TITLE
Fix Docker platform for arm64

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,7 +8,8 @@ on:
 
 env:
   BASE_IMAGE_FOR_LATEST: "bullseye"
-  IMAGE_NAME: "pitop/pi-top-os-deb-build"
+  DOCKER_ACCOUNT_NAME: "vizulize"
+  DOCKER_IMAGE_NAME: "pi-top-os-deb-build"
   PLATFORMS: "linux/amd64,linux/arm64,linux/arm/v7"
 
 jobs:
@@ -42,7 +43,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.DOCKER_ACCOUNT_NAME }}/${{ env.DOCKER_IMAGE_NAME }}
           flavor: |
             latest=${{ matrix.base_image == env.BASE_IMAGE_FOR_LATEST }}
             prefix=${{ matrix.base_image }}-,onlatest=false

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,8 +8,7 @@ on:
 
 env:
   BASE_IMAGE_FOR_LATEST: "bullseye"
-  DOCKER_ACCOUNT_NAME: "vizulize"
-  DOCKER_IMAGE_NAME: "pi-top-os-deb-build"
+  IMAGE_NAME: "pitop/pi-top-os-deb-build"
   PLATFORMS: "linux/amd64,linux/arm64,linux/arm/v7"
 
 jobs:
@@ -43,7 +42,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.DOCKER_ACCOUNT_NAME }}/${{ env.DOCKER_IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
           flavor: |
             latest=${{ matrix.base_image == env.BASE_IMAGE_FOR_LATEST }}
             prefix=${{ matrix.base_image }}-,onlatest=false

--- a/main.js
+++ b/main.js
@@ -100,13 +100,6 @@ async function main() {
         if (targetArchitecture !== "amd64") {
             core.startGroup("Package requires emulation - starting tonistiigi/binfmt")
 
-            const platform_deb_to_docker = {
-                "armhf": "linux/arm/v7",
-                "arm64": "linux/arm64",
-            }
-
-            platform = platform_deb_to_docker[targetArchitecture]
-
             await exec.exec("docker", [
                 "run",
                 "--rm",
@@ -115,6 +108,14 @@ async function main() {
                 "--install",
                 "all",
             ])
+
+            const platform_deb_to_docker = {
+                "armhf": "linux/arm/v7",
+                "arm64": "linux/arm64",
+            }
+
+            platform = platform_deb_to_docker[targetArchitecture]
+
             core.endGroup()
         }
 

--- a/main.js
+++ b/main.js
@@ -24,7 +24,15 @@ async function main() {
         const dockerImage = core.getInput("docker_image") || "debian:stable"
         const sourceRelativeDirectory = core.getInput("source_directory")
         const buildRelativeDirectory = core.getInput("build_directory") || "/tmp/artifacts/bin"
+
         const targetArchitecture = core.getInput("target_architecture") || "amd64"
+        if (targetArchitecture == "armhf") {
+            const dockerArchitecture == "arm/v7"
+        } else {
+            const dockerArchitecture == targetArchitecture
+        }
+
+        const dockerPlatform = "linux/" + dockerArchitecture
 
         const workspaceDirectory = process.cwd()
         const sourceDirectory = path.join(workspaceDirectory, sourceRelativeDirectory)
@@ -68,7 +76,7 @@ async function main() {
             dockerImage: dockerImage,
             sourceDirectory: sourceDirectory,
             buildDirectory: buildDirectory,
-            targetArchitecture: targetArchitecture,
+            dockerPlatform: dockerPlatform,
             DEBUG: DEBUG,
             INSTALL_BUILD_DEPS: INSTALL_BUILD_DEPS,
             BUILD: BUILD,
@@ -96,7 +104,6 @@ async function main() {
         console.log(details)
         core.endGroup()
 
-        let platform = "linux/amd64";
         if (targetArchitecture !== "amd64") {
             core.startGroup("Package requires emulation - starting tonistiigi/binfmt")
 
@@ -108,13 +115,6 @@ async function main() {
                 "--install",
                 "all",
             ])
-
-            const platform_deb_to_docker = {
-                "armhf": "linux/arm/v7",
-                "arm64": "linux/arm64",
-            }
-
-            platform = platform_deb_to_docker[targetArchitecture]
 
             core.endGroup()
         }
@@ -160,7 +160,7 @@ async function main() {
             "--volume", buildDirectory + ":/build",
             "--tty",
             ...envOpts,
-            "--platform", platform,
+            "--platform", dockerPlatform,
             dockerImage,
             "sleep", "inf"
         ])

--- a/main.js
+++ b/main.js
@@ -26,10 +26,9 @@ async function main() {
         const buildRelativeDirectory = core.getInput("build_directory") || "/tmp/artifacts/bin"
 
         const targetArchitecture = core.getInput("target_architecture") || "amd64"
+        let dockerArchitecture == targetArchitecture
         if (targetArchitecture == "armhf") {
-            const dockerArchitecture == "arm/v7"
-        } else {
-            const dockerArchitecture == targetArchitecture
+            dockerArchitecture == "arm/v7"
         }
 
         const dockerPlatform = "linux/" + dockerArchitecture

--- a/main.js
+++ b/main.js
@@ -99,7 +99,14 @@ async function main() {
         let platform = "linux/amd64";
         if (targetArchitecture !== "amd64") {
             core.startGroup("Package requires emulation - starting tonistiigi/binfmt")
-            platform = "linux/arm/v7";
+
+            const platform_deb_to_docker = {
+                "armhf": "linux/arm/v7",
+                "arm64": "linux/arm64",
+            }
+
+            platform = platform_deb_to_docker[targetArchitecture]
+
             await exec.exec("docker", [
                 "run",
                 "--rm",

--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@ async function main() {
         const buildRelativeDirectory = core.getInput("build_directory") || "/tmp/artifacts/bin"
 
         const targetArchitecture = core.getInput("target_architecture") || "amd64"
-        let dockerArchitecture == targetArchitecture
+        let dockerArchitecture = targetArchitecture
         if (targetArchitecture == "armhf") {
             dockerArchitecture == "arm/v7"
         }


### PR DESCRIPTION
Docker platform is currently always `linux/arm/v7` when target architecture doesn't match host. This PR allows for `arm64` Debian package architecture to actually build an arm64 package.